### PR TITLE
chore: remove version specification for pnpm in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,6 @@ jobs:
           persist-credentials: false
 
       - uses: pnpm/action-setup@v5
-        with:
-          version: 10
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

## Why

<!-- Why is this change needed? Link to issue if applicable -->

## Type

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — code restructuring (no behavior change)
- [ ] `perf` — performance improvement
- [ ] `docs` — documentation only
- [ ] `test` — adding or updating tests
- [ ] `chore` — tooling, CI, dependencies
- [ ] `feat!` / `fix!` — breaking change (explain migration below)

## Checklist

- [ ] Types compile (`pnpm typecheck`)
- [ ] Tests pass (`pnpm test`)
- [ ] Build succeeds (`pnpm build`)
- [ ] Public API changes are documented in README
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Breaking changes

<!-- If breaking: describe what changed and how consumers should migrate -->

N/A
