### PR TITLE
fix(gateway): route AI requests to /ai/v1 instead of /ai/api/v1

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,18 +4,18 @@ This document relates **AI Gateway HTTP routes** to how **`@macpaw/ai-sdk`** tal
 
 ## Paths
 
-Gateway routes are versioned under `/api/v1/...`. Use `createGatewayFetch` with the correct path, or let the Vercel/OpenAI stack issue requests under the same prefix.
+Gateway routes are versioned under `/ai/v1/...` (from the host root). With `createGatewayFetch` the base already includes `/ai`, so pass the path relative to it (`/v1/...`). The Vercel/OpenAI stack issues requests under the same prefix automatically.
 
-| API                  | Typical path                   |
-| -------------------- | ------------------------------ |
-| Chat completions     | `/api/v1/chat/completions`     |
-| Responses            | `/api/v1/responses`            |
-| Embeddings           | `/api/v1/embeddings`           |
-| Model info           | `/api/v1/model/info`           |
-| Images generations   | `/api/v1/images/generations`   |
-| Images edits         | `/api/v1/images/edits`         |
-| Audio transcriptions | `/api/v1/audio/transcriptions` |
-| Audio translations   | `/api/v1/audio/translations`   |
+| API                  | Full route (from host)        | Relative path (base `…/ai`) |
+| -------------------- | ----------------------------- | --------------------------- |
+| Chat completions     | `/ai/v1/chat/completions`     | `/v1/chat/completions`      |
+| Responses            | `/ai/v1/responses`            | `/v1/responses`             |
+| Embeddings           | `/ai/v1/embeddings`           | `/v1/embeddings`            |
+| Model info           | `/ai/v1/model/info`           | `/v1/model/info`            |
+| Images generations   | `/ai/v1/images/generations`   | `/v1/images/generations`    |
+| Images edits         | `/ai/v1/images/edits`         | `/v1/images/edits`          |
+| Audio transcriptions | `/ai/v1/audio/transcriptions` | `/v1/audio/transcriptions`  |
+| Audio translations   | `/ai/v1/audio/translations`   | `/v1/audio/translations`    |
 
 ## Base URL
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -24,7 +24,7 @@ The following paths are **not** published in current versions:
 Replace `createAIGatewayClient` with:
 
 1. **Vercel flows** — `createAIGatewayProvider` / `createGatewayProvider` + `generateText` / `streamText` / `embed` from `ai` where the OpenAI-compatible surface is enough.
-2. **Raw JSON or multipart** — `createGatewayFetch({ baseURL, getAuthToken, ... })` then `gatewayFetch('/api/v1/...', { method, headers, body })` (e.g. `FormData` for image edits or audio).
+2. **Raw JSON or multipart** — `createGatewayFetch({ baseURL, getAuthToken, ... })` then `gatewayFetch('/v1/...', { method, headers, body })` (e.g. `FormData` for image edits or audio).
 
 Types for request/response bodies can come from your app, from OpenAI SDK types, or from gateway OpenAPI — they are not re-exported from this package today.
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Internal resolution: `resolveConfig()` in `gateway-config.ts`.
 
 ## `createGatewayFetch` — raw HTTP / multipart
 
-Same auth, retry, middleware, and error normalization as the provider path. Use **relative** URLs under the gateway root (e.g. `'/api/v1/images/edits'`) or absolute URLs that stay under the same gateway origin.
+Same auth, retry, middleware, and error normalization as the provider path. The base already includes `/ai`, so use **relative** URLs under it (e.g. `'/v1/images/edits'`, which resolves to `https://api.macpaw.com/ai/v1/images/edits`) or absolute URLs that stay under the same gateway origin.
 
 ```ts
 import { createGatewayFetch, resolveGatewayBaseURL } from '@macpaw/ai-sdk';
@@ -103,7 +103,7 @@ form.append('image', imageBlob, 'photo.png');
 form.append('prompt', 'Add a hat');
 form.append('model', 'openai/dall-e-2');
 
-const res = await gatewayFetch('/api/v1/images/edits', { method: 'POST', body: form });
+const res = await gatewayFetch('/v1/images/edits', { method: 'POST', body: form });
 ```
 
 Non-gateway absolute URLs are passed through without injecting Bearer auth (placeholder key is stripped). See `gateway-fetch.ts`.

--- a/src/__tests__/gateway-provider.spec.ts
+++ b/src/__tests__/gateway-provider.spec.ts
@@ -51,7 +51,7 @@ describe('createAIGatewayProvider', () => {
 
     expect(mockCreateOpenAI).toHaveBeenCalledTimes(1);
     const config = mockCreateOpenAI.mock.calls[0][0];
-    expect(config.baseURL).toBe('https://api.macpaw.com/ai/api/v1');
+    expect(config.baseURL).toBe('https://api.macpaw.com/ai/v1');
     expect(config.apiKey).toBe('ai-gateway-auth-via-fetch');
     expect(typeof config.fetch).toBe('function');
   });
@@ -79,7 +79,7 @@ describe('createAIGatewayProvider', () => {
     });
 
     const config = mockCreateOpenAI.mock.calls[0][0];
-    expect(config.baseURL).toBe('https://custom.gateway.com/ai/api/v1');
+    expect(config.baseURL).toBe('https://custom.gateway.com/ai/v1');
   });
 
   it('returns the result of createOpenAI', () => {
@@ -241,7 +241,7 @@ describe('createGatewayProvider', () => {
     expect(mockProvider).toHaveBeenCalledWith('custom/claude-opus-4');
     // createOpenAI was called with correct baseURL (production env)
     const config = mockCreateOpenAI.mock.calls[0][0];
-    expect(config.baseURL).toContain('/api/v1');
+    expect(config.baseURL).toContain('/ai/v1');
   });
 
   it('supports "has" trap for property checks', () => {

--- a/src/gateway-fetch.ts
+++ b/src/gateway-fetch.ts
@@ -2,7 +2,7 @@
  * Custom fetch factory for use with Vercel AI SDK and other OpenAI-compatible clients.
  * Use this with createOpenAI({ baseURL, fetch: createGatewayFetch(...) }) or similar.
  *
- * AI Gateway HTTP paths are under /api/v1 (e.g. /api/v1/chat/completions).
+ * AI Gateway HTTP paths are under /ai/v1 (e.g. /ai/v1/chat/completions).
  * So baseURL should be the gateway root, e.g. https://api.macpaw.com/ai
  *
  * Internally delegates to the shared request pipeline while guarding against

--- a/src/gateway-provider.ts
+++ b/src/gateway-provider.ts
@@ -47,7 +47,7 @@ export function createAIGatewayProvider(options: AIGatewayProviderOptions): Open
     name: options.name,
     organization: options.organization,
     project: options.project,
-    baseURL: `${baseURL.replace(/\/$/, '')}/api/${DEFAULT_API_VERSION}`,
+    baseURL: `${baseURL.replace(/\/$/, '')}/${DEFAULT_API_VERSION}`,
     fetch: customFetch,
     apiKey: GATEWAY_PLACEHOLDER_API_KEY,
   });


### PR DESCRIPTION
## What

Drop the redundant `/api` segment from the gateway request path. Provider
requests now target `/ai/v1/...` instead of `/ai/api/v1/...`
(e.g. `https://api.macpaw.com/ai/v1/responses`). Docs and `createGatewayFetch`
examples updated to the new path.

## Why

The `/api` segment was redundant in the gateway route. Both `/ai/v1` and the
legacy `/ai/api/v1` are served in production, so existing consumers keep
working — this is a non-breaking path update that aligns the SDK with the
canonical route.

## Type

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `refactor` — code restructuring (no behavior change)
- [ ] `perf` — performance improvement
- [ ] `docs` — documentation only
- [ ] `test` — adding or updating tests
- [ ] `chore` — tooling, CI, dependencies
- [ ] `feat!` / `fix!` — breaking change (explain migration below)

## Checklist

- [x] Types compile (`pnpm typecheck`)
- [x] Tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [x] Public API changes are documented in README
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Breaking changes

N/A