### PR TITLE
chore: add .jda/config.yaml to onboard JDA

### DIFF
--- a/.jda/config.yaml
+++ b/.jda/config.yaml
@@ -1,0 +1,8 @@
+node:
+  version: 22
+  package_manager: pnpm
+
+additional_tools: pnpm
+
+required_tools: |
+  pnpm --version


### PR DESCRIPTION
## Summary

- Adds `.jda/config.yaml` to configure Node 22 + pnpm for the [junior-dev-runner](https://github.com/MacPaw/junior-dev-runner)
- Fixes pre-flight failure: `pnpm --version exited with 1` (runner had no Node/pnpm installed)

## Why

Without this file the runner skips Node setup entirely, pnpm is unavailable, and the ralph loop is blocked before iteration 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)