### PR TITLE
ci: pin npx CLI versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         id: semantic
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+        run: pnpm exec semantic-release
 
       - name: Release summary
         if: steps.semantic.outputs.new_release_published == 'true'


### PR DESCRIPTION
Pin the versions of CLI tools invoked via `npx` in CI so builds resolve a fixed version instead of whatever is latest-published at run time.